### PR TITLE
update and pin SymPy dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 
 [compat]
+SymPy = "1.2.1"
 PyCall = "1.91"
 julia = "1"
 


### PR DESCRIPTION
`SymbolicTensors.jl` is broken on current master because I left no upper bound on SymPy and they had a breaking 2.0 release.

This is the last 1.x release that passes tests and we should just pin it there.